### PR TITLE
Move @babel/cli to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "rimraf dist && NODE_ENV=production babel src/lib --out-dir dist --copy-files --ignore __tests__,spec.js,test.js,__snapshots__"
   },
   "devDependencies": {
+    "@babel/cli": "^7.7.4",
     "babel-preset-react-app": "^9.1.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
@@ -45,8 +46,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "dependencies": {
-    "@babel/cli": "^7.7.4"
   }
 }


### PR DESCRIPTION
Installing this package should not pull in the Babel CLI as a dependency.