### PR TITLE
feat: remove Fragment import and add autoPlay props

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const App = () => (
        poster="hqdefault" // Defines the image size to call on first render as poster image. Possible values are "default","mqdefault",  "hqdefault", "sddefault" and "maxresdefault". Default value for this prop is "hqdefault". Please be aware that "sddefault" and "maxresdefault", high resolution images are not always avaialble for every video. See: https://stackoverflow.com/questions/2068344/how-do-i-get-a-youtube-video-thumbnail-from-the-youtube-api
        title="YouTube Embed" // a11y, always provide a title for iFrames: https://dequeuniversity.com/tips/provide-iframe-titles Help the web be accessible ;)
        noCookie={true} // Default false, connect to YouTube via the Privacy-Enhanced Mode using https://www.youtube-nocookie.com
-       defaultPlay={false} // Default false, set defaultPlay as `true` will directly show youtube iframe.
+       autoPlay={false} // Default false, set autoPlay as `true` will directly show youtube iframe.
     />
   </div>
 );

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ import { LiteYouTubeEmbed } from "react-lite-youtube-embed";
 const App = () => (
   <div>
     <LiteYouTubeEmbed 
-        id="L2vS_050c-M"
-        title="What’s new in Material Design for the web (Chrome Dev Summit 2019)"
+      id="L2vS_050c-M"
+      title="What’s new in Material Design for the web (Chrome Dev Summit 2019)"
     />
   </div>
 );
@@ -49,7 +49,8 @@ const App = () => (
        playlist={false} // Use  true when your ID be from a playlist
        poster="hqdefault" // Defines the image size to call on first render as poster image. Possible values are "default","mqdefault",  "hqdefault", "sddefault" and "maxresdefault". Default value for this prop is "hqdefault". Please be aware that "sddefault" and "maxresdefault", high resolution images are not always avaialble for every video. See: https://stackoverflow.com/questions/2068344/how-do-i-get-a-youtube-video-thumbnail-from-the-youtube-api
        title="YouTube Embed" // a11y, always provide a title for iFrames: https://dequeuniversity.com/tips/provide-iframe-titles Help the web be accessible ;)
-       noCookie={true} //Default false, connect to YouTube via the Privacy-Enhanced Mode using https://www.youtube-nocookie.com
+       noCookie={true} // Default false, connect to YouTube via the Privacy-Enhanced Mode using https://www.youtube-nocookie.com
+       defaultPlay={false} // Default false, set defaultPlay as `true` will directly show youtube iframe.
     />
   </div>
 );

--- a/dist/LiteYouTubeEmbed.js
+++ b/dist/LiteYouTubeEmbed.js
@@ -13,14 +13,14 @@ var LiteYouTubeEmbed = function LiteYouTubeEmbed(_ref) {
       iframeClass = _ref.iframeClass,
       playerClass = _ref.playerClass,
       wrapperClass = _ref.wrapperClass,
-      defaultPlay = _ref.defaultPlay;
+      autoPlay = _ref.autoPlay;
 
   var _useState = useState(false),
       _useState2 = _slicedToArray(_useState, 2),
       preconnected = _useState2[0],
       setPreconnected = _useState2[1];
 
-  var _useState3 = useState(defaultPlay),
+  var _useState3 = useState(autoPlay),
       _useState4 = _slicedToArray(_useState3, 2),
       iframeLoaded = _useState4[0],
       setIframeLoaded = _useState4[1];
@@ -90,6 +90,6 @@ LiteYouTubeEmbed.defaultProps = {
   iframeClass: "",
   playerClass: "lty-playbtn",
   wrapperClass: "yt-lite",
-  defaultPlay: false
+  autoPlay: false
 };
 export default LiteYouTubeEmbed;

--- a/dist/LiteYouTubeEmbed.js
+++ b/dist/LiteYouTubeEmbed.js
@@ -1,5 +1,5 @@
 import _slicedToArray from "@babel/runtime/helpers/esm/slicedToArray";
-import React, { Fragment, useState } from "react";
+import React, { useState } from "react";
 import "./LiteYouTubeEmbed.css";
 
 var LiteYouTubeEmbed = function LiteYouTubeEmbed(_ref) {
@@ -12,17 +12,18 @@ var LiteYouTubeEmbed = function LiteYouTubeEmbed(_ref) {
       activatedClass = _ref.activatedClass,
       iframeClass = _ref.iframeClass,
       playerClass = _ref.playerClass,
-      wrapperClass = _ref.wrapperClass;
+      wrapperClass = _ref.wrapperClass,
+      defaultPlay = _ref.defaultPlay;
 
   var _useState = useState(false),
       _useState2 = _slicedToArray(_useState, 2),
       preconnected = _useState2[0],
       setPreconnected = _useState2[1];
 
-  var _useState3 = useState(false),
+  var _useState3 = useState(defaultPlay),
       _useState4 = _slicedToArray(_useState3, 2),
-      iframe = _useState4[0],
-      setIframe = _useState4[1];
+      iframeLoaded = _useState4[0],
+      setIframeLoaded = _useState4[1];
 
   var videoId = encodeURIComponent(id);
   var videoTitle = title;
@@ -36,11 +37,11 @@ var LiteYouTubeEmbed = function LiteYouTubeEmbed(_ref) {
   };
 
   var addIframe = function addIframe() {
-    if (iframe) return;
-    setIframe(true);
+    if (iframeLoaded) return;
+    setIframeLoaded(true);
   };
 
-  return React.createElement(Fragment, null, React.createElement("link", {
+  return React.createElement(React.Fragment, null, React.createElement("link", {
     rel: "preload",
     href: posterUrl,
     as: "image"
@@ -59,14 +60,14 @@ var LiteYouTubeEmbed = function LiteYouTubeEmbed(_ref) {
   })))), React.createElement("div", {
     onPointerOver: warmConnections,
     onClick: addIframe,
-    className: "".concat(wrapperClass, " ").concat(iframe && activatedClass),
+    className: "".concat(wrapperClass, " ").concat(iframeLoaded && activatedClass),
     "data-title": videoTitle,
     style: {
       backgroundImage: "url(".concat(posterUrl, ")")
     }
   }, React.createElement("div", {
     className: playerClass
-  }), iframe && React.createElement("iframe", {
+  }), iframeLoaded && React.createElement("iframe", {
     className: iframeClass,
     title: videoTitle,
     width: "560",
@@ -88,6 +89,7 @@ LiteYouTubeEmbed.defaultProps = {
   activatedClass: "lyt-activated",
   iframeClass: "",
   playerClass: "lty-playbtn",
-  wrapperClass: "yt-lite"
+  wrapperClass: "yt-lite",
+  defaultPlay: false
 };
 export default LiteYouTubeEmbed;

--- a/src/lib/LiteYouTubeEmbed.js
+++ b/src/lib/LiteYouTubeEmbed.js
@@ -1,13 +1,24 @@
-import React, { Fragment, useState } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 
 import "./LiteYouTubeEmbed.css";
 
-const LiteYouTubeEmbed = ({ adNetwork, id, playlist, poster, title, noCookie, activatedClass, iframeClass, playerClass, wrapperClass
+const LiteYouTubeEmbed = ({ 
+  adNetwork, 
+  id, 
+  playlist, 
+  poster, 
+  title, 
+  noCookie, 
+  activatedClass, 
+  iframeClass, 
+  playerClass, 
+  wrapperClass, 
+  defaultPlay
 }) => {
 
   const [preconnected, setPreconnected] = useState(false);
-  const [iframe, setIframe] = useState(false);
+  const [iframeLoaded, setIframeLoaded] = useState(defaultPlay);
   const videoId = encodeURIComponent(id);
   const videoTitle = title;
   const posterUrl = `https://i.ytimg.com/vi/${videoId}/${poster}.jpg`;
@@ -24,12 +35,12 @@ const LiteYouTubeEmbed = ({ adNetwork, id, playlist, poster, title, noCookie, ac
   };
 
   const addIframe = () => {
-    if (iframe) return;
-    setIframe(true);
+    if (iframeLoaded) return;
+    setIframeLoaded(true);
   };
 
   return (
-    <Fragment>
+    <>
       <link rel="preload" href={posterUrl} as="image" />
       <>
       {preconnected && (
@@ -49,12 +60,12 @@ const LiteYouTubeEmbed = ({ adNetwork, id, playlist, poster, title, noCookie, ac
       <div
         onPointerOver={warmConnections}
         onClick={addIframe}
-        className={`${wrapperClass} ${iframe && activatedClass}`}
+        className={`${wrapperClass} ${iframeLoaded && activatedClass}`}
         data-title={videoTitle}
         style={{ backgroundImage: `url(${posterUrl})` }}
       >
         <div className={playerClass}></div>
-        {iframe && (
+        {iframeLoaded && (
           <iframe
             className={iframeClass}
             title={videoTitle}
@@ -67,7 +78,7 @@ const LiteYouTubeEmbed = ({ adNetwork, id, playlist, poster, title, noCookie, ac
           ></iframe>
         )}
       </div>
-    </Fragment>
+    </>
   );
 };
 
@@ -81,7 +92,8 @@ LiteYouTubeEmbed.propTypes = {
   activatedClass: PropTypes.string,
   iframeClass: PropTypes.string,
   playerClass: PropTypes.string,
-  wrapperClass: PropTypes.string
+  wrapperClass: PropTypes.string,
+  defaultPlay: PropTypes.bool
 };
 
 LiteYouTubeEmbed.defaultProps = {
@@ -95,6 +107,7 @@ LiteYouTubeEmbed.defaultProps = {
   iframeClass: "",
   playerClass: "lty-playbtn",
   wrapperClass: "yt-lite",
+  defaultPlay: false
 };
 
 export default LiteYouTubeEmbed;

--- a/src/lib/LiteYouTubeEmbed.js
+++ b/src/lib/LiteYouTubeEmbed.js
@@ -14,11 +14,11 @@ const LiteYouTubeEmbed = ({
   iframeClass, 
   playerClass, 
   wrapperClass, 
-  defaultPlay
+  autoPlay
 }) => {
 
   const [preconnected, setPreconnected] = useState(false);
-  const [iframeLoaded, setIframeLoaded] = useState(defaultPlay);
+  const [iframeLoaded, setIframeLoaded] = useState(autoPlay);
   const videoId = encodeURIComponent(id);
   const videoTitle = title;
   const posterUrl = `https://i.ytimg.com/vi/${videoId}/${poster}.jpg`;
@@ -93,7 +93,7 @@ LiteYouTubeEmbed.propTypes = {
   iframeClass: PropTypes.string,
   playerClass: PropTypes.string,
   wrapperClass: PropTypes.string,
-  defaultPlay: PropTypes.bool
+  autoPlay: PropTypes.bool
 };
 
 LiteYouTubeEmbed.defaultProps = {
@@ -107,7 +107,7 @@ LiteYouTubeEmbed.defaultProps = {
   iframeClass: "",
   playerClass: "lty-playbtn",
   wrapperClass: "yt-lite",
-  defaultPlay: false
+  autoPlay: false
 };
 
 export default LiteYouTubeEmbed;


### PR DESCRIPTION
Sorry is me again and thanks for replying the previous PR so quick ! I Really appreciate!

Below is what I did in this pull request:

- remove  Fragment import and use <> </>
- change state name 'iframe' to 'iframeLoaded', I think it is more meaningful and it can also reduce the chance of confusion with nature iframe element.
- add autoPlay props (Maybe some users want to play the video directly while loaded)
