### PR TITLE
feat: add aspectHeight and aspectWidth

### DIFF
--- a/src/lib/LiteYouTubeEmbed.css
+++ b/src/lib/LiteYouTubeEmbed.css
@@ -23,7 +23,7 @@
 .yt-lite:after {
   content: "";
   display: block;
-  padding-bottom: 56.25%;
+  padding-bottom: var(--aspect-ratio);
 }
 .yt-lite > iframe {
   width: 100%;

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useState } from "react";
 
 type imgResolution =
   | "default"
@@ -13,6 +12,8 @@ interface LiteYouTube {
   title: string;
   activatedClass?: string;
   adNetwork?: boolean;
+  aspectHeight?: number;
+  aspectWidth?: number;
   iframeClass?: string;
   noCookie?: boolean;
   cookie?: boolean;
@@ -26,8 +27,8 @@ interface LiteYouTube {
 }
 
 export default function LiteYouTubeEmbed(props: LiteYouTube) {
-  const [preconnected, setPreconnected] = useState(false);
-  const [iframe, setIframe] = useState(false);
+  const [preconnected, setPreconnected] = React.useState(false);
+  const [iframe, setIframe] = React.useState(false);
   const videoId = encodeURIComponent(props.id);
   const videoPlaylisCovertId = typeof props.playlistCoverId === 'string' ? encodeURIComponent(props.playlistCoverId) : null;
   const videoTitle = props.title;
@@ -48,6 +49,8 @@ export default function LiteYouTubeEmbed(props: LiteYouTube) {
 
   const activatedClassImp = props.activatedClass || "lyt-activated";
   const adNetworkImp = props.adNetwork || false;
+  const aspectHeight = props.aspectHeight || 9;
+  const aspectWidth = props.aspectWidth || 16;
   const iframeClassImp = props.iframeClass || "";
   const playerClassImp = props.playerClass || "lty-playbtn";
   const wrapperClassImp = props.wrapperClass || "yt-lite";
@@ -89,7 +92,12 @@ export default function LiteYouTubeEmbed(props: LiteYouTube) {
         onClick={addIframe}
         className={`${wrapperClassImp} ${iframe && activatedClassImp}`}
         data-title={videoTitle}
-        style={{ backgroundImage: `url(${posterUrl})` }}
+        style={{
+          backgroundImage: `url(${posterUrl})`,
+          ...({
+            '--aspect-ratio': `${(aspectHeight / aspectWidth) * 100}%`,
+          } as React.CSSProperties),
+        }}
       >
         <div className={playerClassImp}></div>
         {iframe && (


### PR DESCRIPTION
Hey Ibrahim!
I haven't tested it yet, but I believe it should work. 
I am adding 2 additional props which are:
`aspectHeight` and `aspectWidth`

I have a problem when linking the lib in my local, like this
![image](https://user-images.githubusercontent.com/55318172/126054110-8dc68b9c-d1ab-4a3f-898a-97f0a8bd9206.png)

```
Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
```