### PR TITLE
Make `thumbnail` parameter optional

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -27,7 +27,7 @@ interface LiteYouTube {
   wrapperClass?: string;
   onIframeAdded?: () => void
   muted?: boolean,
-  thumbnail: string,
+  thumbnail?: string,
 }
 
 export default function LiteYouTubeEmbed(props: LiteYouTube) {


### PR DESCRIPTION
A very small thing that was missed in #47