### PR TITLE
Fix gradient in projects with Tailwind

### DIFF
--- a/src/lib/LiteYouTubeEmbed.css
+++ b/src/lib/LiteYouTubeEmbed.css
@@ -8,6 +8,7 @@
   cursor: pointer;
 }
 .yt-lite:before {
+  box-sizing: content-box;
   content: "";
   display: block;
   position: absolute;


### PR DESCRIPTION
We use Tailwind in our project, and Tailwind’s reset styles set all `box-sizing` to `border-box`. This breaks the gradient, so I have added an explicit instruction to use `content-box` sizing instead.