### PR TITLE
feat: forward ref to yt iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ const App = () => (
        id="L2vS_050c-M" // Default none, id of the video or playlist
        adNetwork={true} // Default true, to preconnect or not to doubleclick addresses called by YouTube iframe (the adnetwork from Google)
        params="" // any params you want to pass to the URL, assume we already had '&' and pass your parameters string
-       playlist={false} // Use  true when your ID be from a playlist
+       playlist={false} // Use true when your ID be from a playlist
        playlistCoverId="L2vS_050c-M" // The ids for playlists did not bring the cover in a pattern to render so you'll need pick up a video from the playlist (or in fact, whatever id) and use to render the cover. There's a programmatic way to get the cover from YouTube API v3 but the aim of this component is do not make any another call and reduce requests and bandwidth usage as much as possibe
        poster="hqdefault" // Defines the image size to call on first render as poster image. Possible values are "default","mqdefault",  "hqdefault", "sddefault" and "maxresdefault". Default value for this prop is "hqdefault". Please be aware that "sddefault" and "maxresdefault", high resolution images are not always avaialble for every video. See: https://stackoverflow.com/questions/2068344/how-do-i-get-a-youtube-video-thumbnail-from-the-youtube-api
        title="YouTube Embed" // a11y, always provide a title for iFrames: https://dequeuniversity.com/tips/provide-iframe-titles Help the web be accessible ;)
-       noCookie={true} //Default false, connect to YouTube via the Privacy-Enhanced Mode using https://www.youtube-nocookie.com
+       noCookie={true} // Default false, connect to YouTube via the Privacy-Enhanced Mode using https://www.youtube-nocookie.com
+       ref={myRef} // Use this ref prop to programmatically access the underlying iframe element
     />
   </div>
 );

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+
 export type imgResolution =
   | "default"
   | "mqdefault"
@@ -7,7 +8,7 @@ export type imgResolution =
   | "sddefault"
   | "maxresdefault";
 
-export interface LiteYouTube {
+export interface LiteYouTubeProps {
   announce?: string;
   id: string;
   title: string;
@@ -31,7 +32,7 @@ export interface LiteYouTube {
   rel?: string,
 }
 
-export default function LiteYouTubeEmbed(props: LiteYouTube) {
+function LiteYouTubeEmbedComponent(props: LiteYouTubeProps, ref: HTMLIFrameElement) {
   const [preconnected, setPreconnected] = React.useState(false);
   const [iframe, setIframe] = React.useState(false);
   const videoId = encodeURIComponent(props.id);
@@ -126,6 +127,7 @@ export default function LiteYouTubeEmbed(props: LiteYouTube) {
           aria-label={`${announceWatch} ${videoTitle}`} />
         {iframe && (
           <iframe
+            ref={ref}
             className={iframeClassImp}
             title={videoTitle}
             width="560"
@@ -140,3 +142,5 @@ export default function LiteYouTubeEmbed(props: LiteYouTube) {
     </>
   );
 }
+
+export default React.forwardRef<HTMLIFrameElement,LiteYouTubeProps>(LiteYouTubeEmbedComponent)


### PR DESCRIPTION
Add a ref prop that is being forwarde to the iFrame element, so the user can get programmatic access to the iFrame element (e.g. to start playback).