### PR TITLE
fix: Use .js extensions for dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-lite-youtube-embed",
   "version": "2.3.5",
   "description": "A private by default, faster and cleaner YouTube embed component for React applications",
-  "main": "dist/index.jsx",
-  "module": "dist/index.es.jsx",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "npx rollup -c"


### PR DESCRIPTION
- Fixes #92 

This makes it possible to use `react-lite-youtube-embed` in setups in which Node is importing directly, without a bundler. I haven't run rebuild, assuming that you do that before rolling releases.