### PR TITLE
fix: parse props.params

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -33,7 +33,7 @@ export interface LiteYouTubeProps {
 
 function LiteYouTubeEmbedComponent(
   props: LiteYouTubeProps,
-  ref: React.Ref<HTMLIFrameElement>
+  ref: React.Ref<HTMLIFrameElement>,
 ) {
   const [preconnected, setPreconnected] = React.useState(false);
   const [iframe, setIframe] = React.useState(props.alwaysLoadIframe || false);
@@ -57,6 +57,16 @@ function LiteYouTubeEmbedComponent(
     ...(props.enableJsApi ? { enablejsapi: "1" } : {}),
     ...(props.playlist ? { list: videoId } : {}),
   });
+
+  // parse props.params into individual search parameters and append them to iframeParams
+  if (props.params) {
+    const additionalParams = new URLSearchParams(
+      props.params.startsWith("&") ? props.params.slice(1) : props.params,
+    );
+    additionalParams.forEach((value, key) => {
+      iframeParams.append(key, value);
+    });
+  }
 
   let ytUrl = props.noCookie
     ? "https://www.youtube-nocookie.com"
@@ -171,5 +181,5 @@ function LiteYouTubeEmbedComponent(
 }
 
 export default React.forwardRef<HTMLIFrameElement, LiteYouTubeProps>(
-  LiteYouTubeEmbedComponent
+  LiteYouTubeEmbedComponent,
 );


### PR DESCRIPTION
This PR fixes [an issue introduced on this PR](https://github.com/ibrahimcesar/react-lite-youtube-embed/pull/118/files#diff-c73f89cf9c10b6e7519c332715368c100d0b1ce7864a891a4f1c3ca7f5f47addL43) where `props.params` are not being passed to the iframe `src` parameter:

```
<LiteYouTubeEmbed params="start=1160&foo=bar" />

```

BEFORE FIX:

```
<iframe src="https://www.youtube-nocookie.com/embed/L2vS_050c-M?"></iframe> // <-- notice no params are passed to src
```

AFTER FIX:

```
<iframe src="https://www.youtube-nocookie.com/embed/L2vS_050c-M?start=1160&amp;foo=bar"></iframe> // <-- props.params are correctly passed to src
```