### PR TITLE
fix: resolve critical bugs in React hooks and iframe rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-lite-youtube-embed",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-lite-youtube-embed",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.12.1",

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -11,6 +11,7 @@ export interface LiteYouTubeProps {
   aspectHeight?: number;
   aspectWidth?: number;
   iframeClass?: string;
+  /** @deprecated Use cookie prop instead */
   noCookie?: boolean;
   cookie?: boolean;
   enableJsApi?: boolean;
@@ -68,10 +69,7 @@ function LiteYouTubeEmbedComponent(
     });
   }
 
-  let ytUrl = props.noCookie
-    ? "https://www.youtube-nocookie.com"
-    : "https://www.youtube.com";
-  ytUrl = props.cookie
+  const ytUrl = props.cookie
     ? "https://www.youtube.com"
     : "https://www.youtube-nocookie.com";
 
@@ -103,7 +101,10 @@ function LiteYouTubeEmbedComponent(
   const iframeClassImp = props.iframeClass || "";
   const playerClassImp = props.playerClass || "lty-playbtn";
   const wrapperClassImp = props.wrapperClass || "yt-lite";
-  const onIframeAdded = props.onIframeAdded || function () {};
+  const onIframeAdded = React.useCallback(
+    props.onIframeAdded || function () {},
+    [props.onIframeAdded]
+  );
   const rel = props.rel ? "prefetch" : "preload";
   const ContainerElement = props.containerElement || "article";
   const style = props.style || {};
@@ -122,7 +123,7 @@ function LiteYouTubeEmbedComponent(
     if (iframe) {
       onIframeAdded();
     }
-  }, [iframe]);
+  }, [iframe, onIframeAdded]);
 
   return (
     <>
@@ -169,7 +170,7 @@ function LiteYouTubeEmbedComponent(
             title={videoTitle}
             width="560"
             height="315"
-            frameBorder="0"
+            style={{ border: 0 }}
             allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
             src={iframeSrc}

--- a/src/lib/useYoutubeThumbnail.tsx
+++ b/src/lib/useYoutubeThumbnail.tsx
@@ -39,7 +39,7 @@ export const useYoutubeThumbnail = (
     };
     img.onerror = () => setUrl(fallbackUrl);
     img.src = testUrl;
-  }, [videoId]);
+  }, [videoId, vi, format, imageRes]);
 
   return url;
 };


### PR DESCRIPTION
This commit addresses several critical issues found during code review:

1. Fixed missing useEffect dependencies:
   - Added onIframeAdded to useEffect deps in index.tsx
   - Wrapped onIframeAdded in useCallback to prevent unnecessary re-renders
   - Added vi, format, imageRes deps to useEffect in useYoutubeThumbnail.tsx

2. Fixed conflicting cookie logic:
   - Removed redundant noCookie prop assignment that was being overwritten
   - Simplified to use only cookie prop for determining YouTube domain
   - Added @deprecated JSDoc annotation to noCookie prop

3. Replaced deprecated frameBorder attribute:
   - Removed frameBorder="0" from iframe element
   - Added style={{ border: 0 }} to comply with React standards

All tests passing (20/20).