### PR TITLE
fix: add fallback value to --aspect-ratio CSS custom property

### DIFF
--- a/dist/LiteYouTubeEmbed.css
+++ b/dist/LiteYouTubeEmbed.css
@@ -25,7 +25,7 @@
 .yt-lite::after {
   content: "";
   display: block;
-  padding-bottom: var(--aspect-ratio);
+  padding-bottom: var(--aspect-ratio, 56.25%);
 }
 .yt-lite > iframe {
   width: 100%;

--- a/src/lib/LiteYouTubeEmbed.css
+++ b/src/lib/LiteYouTubeEmbed.css
@@ -25,7 +25,7 @@
 .yt-lite::after {
   content: "";
   display: block;
-  padding-bottom: var(--aspect-ratio);
+  padding-bottom: var(--aspect-ratio, 56.25%);
 }
 .yt-lite > iframe {
   width: 100%;


### PR DESCRIPTION
Fixes #65

Added a fallback value of 56.25% (16:9 aspect ratio) to the --aspect-ratio custom property to prevent build warnings from postcss-custom-properties.

The fallback ensures that:
- The component displays correctly even if the custom property is not set
- Build tools like postcss-custom-properties don't generate warnings
- The standard YouTube 16:9 aspect ratio is maintained by default

The custom property is still dynamically set in the component for custom aspect ratios, but now has a sensible fallback for better compatibility.