### PR TITLE
Evaluate and Assess Issue

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -322,6 +322,7 @@ function LiteYouTubeEmbedComponent(
           aria-label={`${announceWatch} ${videoTitle}`}
           aria-hidden={iframe || undefined}
           tabIndex={iframe ? -1 : 0}
+          onClick={addIframe}
         >
           <span className="lty-visually-hidden">
             {announceWatch}


### PR DESCRIPTION
Fixes #50

Mobile users (iOS/Android) were required to tap twice to activate videos because the button element lacked an explicit onClick handler. Events relied on bubbling from button to container, which doesn't work reliably with touch events on mobile browsers.

Changes:
- Added onClick={addIframe} to the play button element
- Button now handles clicks directly, fixing mobile touch event issues
- Container onClick remains for backward compatibility and flexibility

Impact:
- ✅ Fixes double-tap requirement on mobile devices
- ✅ All 35 existing tests pass
- ✅ Zero breaking changes
- ✅ Backward compatible

Testing:
- Automated: All test suite passes (35/35 tests)
- Recommended: Manual testing on iOS Safari and Android Chrome