### PR TITLE
fix: resolve Safari black margin issue on iframe (#104)

### DIFF
--- a/src/lib/LiteYouTubeEmbed.css
+++ b/src/lib/LiteYouTubeEmbed.css
@@ -2,7 +2,7 @@
   background-color: #000;
   position: relative;
   display: block;
-  contain: content;
+  contain: layout style;
   background-position: 50%;
   background-size: cover;
   cursor: pointer;
@@ -33,6 +33,12 @@
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
+  border: 0;
+  outline: 0;
+  margin: 0;
+  padding: 0;
+  display: block;
 }
 .yt-lite > .lty-thumbnail {
   position: absolute;

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -335,7 +335,6 @@ function LiteYouTubeEmbedComponent(
             title={videoTitle}
             width="560"
             height="315"
-            style={{ border: 0 }}
             allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
             src={iframeSrc}


### PR DESCRIPTION
Fixes Safari-specific rendering bug where a black margin appeared on the left side of the YouTube iframe during video playback.

Changes:
- Add comprehensive CSS reset for iframe (border, outline, margin, padding)
- Add explicit right: 0 positioning to prevent width calculation issues
- Add display: block to prevent inline spacing artifacts
- Change CSS containment from 'content' to 'layout style' for better Safari support
- Remove redundant inline style={{ border: 0 }} from iframe JSX

Safari's rendering engine has known issues with:
1. CSS contain: content property causing unexpected layout calculations
2. Default outline/margin styles persisting despite border: 0
3. Width calculations when using left: 0 without right: 0

Testing: All 35 tests passing ✅

Fixes #94