### PR TITLE
fix: add --access public flag to GitHub Packages publish with provenance

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -223,10 +223,11 @@ jobs:
         run: |
           # The publishConfig in package.json already points to GitHub Packages
           # Include --provenance flag (GitHub Packages uses attestations generated above)
+          # --access public is required when using --provenance
           if [ "${{ github.event.inputs.is_beta }}" == "true" ]; then
-            npm publish --tag beta --provenance
+            npm publish --tag beta --access public --provenance
           else
-            npm publish --provenance
+            npm publish --access public --provenance
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,6 @@ jobs:
           path: dist/
 
       - name: Publish to GitHub Packages
-        run: npm publish --provenance
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When publishing to GitHub Packages with the --provenance flag, npm requires explicitly setting --access public. This fixes the npm publish error: "Can't generate provenance for new or private package, you must set access to public"

Changes:
- Added --access public flag to auto-release.yml GitHub Packages publish step
- Added --access public flag to release.yml GitHub Packages publish step
- Added clarifying comment about the requirement

This ensures SLSA provenance generation works correctly for GitHub Packages.