### PR TITLE
fix: Update test badge to show '51 / 51 tests' format

### DIFF
--- a/.github/badges/tests.json
+++ b/.github/badges/tests.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "tests",
-  "message": "51/51 passing",
+  "message": "51 / 51 tests",
   "color": "brightgreen"
 }

--- a/.github/workflows/test-badge.yml
+++ b/.github/workflows/test-badge.yml
@@ -76,7 +76,7 @@ jobs:
           {
             "schemaVersion": 1,
             "label": "tests",
-            "message": "${{ steps.test.outputs.passed }}/${{ steps.test.outputs.total }} passing",
+            "message": "${{ steps.test.outputs.passed }} / ${{ steps.test.outputs.total }} tests",
             "color": "${{ steps.test.outputs.color }}"
           }
           EOF


### PR DESCRIPTION
- Changed badge message from "51/51 passing" to "51 / 51 tests"
- Added spaces for better readability
- More descriptive badge text that includes "tests"
- Updated both workflow and current badge data