### PR TITLE
chore: demo errors

### DIFF
--- a/demo/pages/404.js
+++ b/demo/pages/404.js
@@ -16,8 +16,9 @@ export default function Custom404() {
         <p className={styles.description}>
           The page you are looking for does not exist.
         </p>
-        <Link href="/">
-          <a style={{
+        <Link
+          href="/"
+          style={{
             marginTop: '2rem',
             padding: '0.75rem 1.5rem',
             minHeight: '48px',
@@ -31,17 +32,15 @@ export default function Custom404() {
             textDecoration: 'none',
             fontWeight: '600',
             transition: 'all 0.2s ease'
-          }}>
-            Go back home
-          </a>
+          }}
+        >
+          Go back home
         </Link>
       </main>
 
       <footer className={styles.footer}>
         <Link href="/">
-          <a>
-            Demo for <span role="img" aria-label="TV" style={{marginLeft: "5px", marginRight: "5px"}}>📺</span> React Lite YouTube Embed
-          </a>
+          Demo for <span role="img" aria-label="TV" style={{marginLeft: "5px", marginRight: "5px"}}>📺</span> React Lite YouTube Embed
         </Link>
       </footer>
     </div>

--- a/demo/pages/_document.js
+++ b/demo/pages/_document.js
@@ -5,7 +5,6 @@ export default function Document() {
     <Html lang="en">
       <Head>
         <meta name="description" content="React Lite YouTube Embed - A private by default, faster and cleaner YouTube embed component for React applications. Improve performance with lazy loading, WebP thumbnails, and privacy-enhanced mode." />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link


### PR DESCRIPTION
- Remove <a> child elements from Next.js Link components in 404.js
  - Modern Next.js (13+) automatically renders <a> tags
  - Moved styles directly to Link component
- Remove viewport meta tag from _document.js
  - Next.js recommends not using viewport in _document.js
  - Next.js uses sensible viewport defaults

Fixes:
- "Invalid <Link> with <a> child" errors
- "viewport meta tags should not be used in _document.js" warning