### PR TITLE
fix: demo display issue

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "@ibrahimcesar/react-lite-youtube-embed",
-      "version": "3.0.6",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/file": "^11.1.6",

--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import LiteYouTubeEmbed from "react-lite-youtube-embed"
+import LiteYouTubeEmbed from "@ibrahimcesar/react-lite-youtube-embed"
 import Prism from "prismjs"
 import packageInfo from "../package.json"
 


### PR DESCRIPTION
Problem:
- Demo was importing from "react-lite-youtube-embed" (v2.6.0 from npm)
- This old version doesn't have the event timing fix from PR #203
- CHECKPOINT 2 wasn't showing because onReady events weren't firing

Solution:
- Changed import to "@ibrahimcesar/react-lite-youtube-embed"
- This uses the local source code (file:..) with all latest fixes
- Rebuilt package and reinstalled demo dependencies

Impact:
- Demo now uses latest event handling code
- CHECKPOINT 2 (Player Ready) should now appear consistently
- All event handlers will work properly

Fixes: CHECKPOINT 2 visibility issue reported by user