### PR TITLE
fix: react JSX runtime module not found error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "es2018", "dom", "es6"
       ],
       "moduleResolution": "node",
-      "jsx": "react",
+      "jsx": "react-jsx",
       "forceConsistentCasingInFileNames": true,
       "noImplicitReturns": true,
       "noImplicitThis": true,


### PR DESCRIPTION
Updated tsconfig.json to use the new JSX transform (react-jsx) instead of the legacy transform (react). This aligns TypeScript's compilation with Vite's @vitejs/plugin-react which uses the new JSX transform by default.

This fixes the module resolution issue where the build output correctly imports from 'react/jsx-runtime' (marked as external in vite.config.ts) but TypeScript was configured for the old transform.

Changes:
- tsconfig.json: Changed "jsx": "react" to "jsx": "react-jsx"

Benefits:
- Eliminates JSX transform mismatch between TypeScript and Vite
- Aligns with React 17+ best practices
- Maintains backward compatibility (source still imports React)
- All 51 tests passing ✅