### PR TITLE
Update Node Usage in RU Module

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,10 +36,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -215,7 +215,7 @@ jobs:
       - name: Setup Node for GitHub Packages
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ibrahimcesar'
 

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Get version to deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Node.js for NPM
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download build artifacts
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Node.js for GitHub Packages
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ibrahimcesar'
 

--- a/.github/workflows/size-badges.yml
+++ b/.github/workflows/size-badges.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Node 20
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/demo/package.json
+++ b/demo/package.json
@@ -16,8 +16,5 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-lite-youtube-embed": "2.6.0"
-  },
-  "volta": {
-    "node": "20.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,9 +83,6 @@
     "vite-plugin-dts": "^4.3.0",
     "vitest": "^3.2.4"
   },
-  "volta": {
-    "node": "20.10.0"
-  },
   "size-limit": [
     {
       "name": "ES Module",


### PR DESCRIPTION
- Remove Volta pin from package.json files (was 20.10.0)
- Update all GitHub Actions workflows to use Node 22 (latest LTS)
- Updated workflows: ci, release, auto-release, coverage, bundle-size, deploy-demo, size-badges
- Allows automatic adoption of latest Node 22.x versions in CI/CD