### PR TITLE
chore: Upgrade vite-plugin-dts and suppress TypeScript version warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "size-limit": "^11.1.6",
         "typescript": "^5.9.3",
         "vite": "^7.2.2",
-        "vite-plugin-dts": "^4.3.0",
+        "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.2.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "size-limit": "^11.1.6",
     "typescript": "^5.9.3",
     "vite": "^7.2.2",
-    "vite-plugin-dts": "^4.3.0",
+    "vite-plugin-dts": "^4.5.4",
     "vitest": "^3.2.4"
   },
   "volta": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,16 @@ export default defineConfig({
     dts({
       include: ['src/lib'],
       rollupTypes: true,
+      rollupOptions: {
+        messageCallback: (message) => {
+          // Suppress console messages (like the TypeScript version warning)
+          // API Extractor uses TypeScript 5.8.2 which is older than our project's 5.9.3
+          // This is generally harmless as API Extractor only reads .d.ts files
+          if (message.messageId.startsWith('console-')) {
+            message.handled = true;
+          }
+        },
+      },
     }),
     {
       name: 'copy-files-and-add-banner',


### PR DESCRIPTION
- Upgraded vite-plugin-dts from 4.3.0 to 4.5.4
- Updated @microsoft/api-extractor from ^7.47.11 to ^7.50.1 (via vite-plugin-dts)
- Configured messageCallback to suppress console-prefixed warnings
- The TypeScript 5.9.3 vs 5.8.2 version mismatch is harmless as API Extractor only reads .d.ts files

Build now completes cleanly without warnings.
All 51 tests passing ✅