### PR TITLE
fix: Remove --cleanup-tag and --verify-tag to prevent workflow failure

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -222,10 +222,10 @@ jobs:
         run: |
           TAG_NAME="${{ steps.bump_version.outputs.version }}"
 
-          # Delete existing release if it exists
+          # Delete existing release if it exists (but keep the tag - we handle that separately)
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             echo "Release $TAG_NAME already exists, deleting it"
-            gh release delete "$TAG_NAME" --yes --cleanup-tag || true
+            gh release delete "$TAG_NAME" --yes || true
           fi
 
           # Create new release
@@ -233,13 +233,11 @@ jobs:
             gh release create "$TAG_NAME" \
               --title "Release $TAG_NAME (Beta)" \
               --notes-file CHANGELOG.md \
-              --verify-tag \
               --prerelease
           else
             gh release create "$TAG_NAME" \
               --title "Release $TAG_NAME" \
-              --notes-file CHANGELOG.md \
-              --verify-tag
+              --notes-file CHANGELOG.md
           fi
 
       - name: Publish to NPM


### PR DESCRIPTION
Fixes the workflow error: "tag doesn't exist in the repo, aborting due to --verify-tag flag"

The issue occurred because:
1. "Create and push tag" step creates and pushes the tag
2. "Create GitHub Release" step deletes the release with --cleanup-tag (which also deletes the tag we just created!)
3. Then tries to create release with --verify-tag for a non-existent tag

Changes:
- Removed --cleanup-tag from gh release delete (tag deletion is handled in the "Create and push tag" step)
- Removed --verify-tag from gh release create (not needed since we just created and pushed the tag)

Now the workflow correctly:
1. Deletes old tag if exists
2. Creates and pushes new tag
3. Deletes old release (without touching the tag)
4. Creates new release using the freshly pushed tag ✅

This fix is required for the "none" version bump option to work properly when republishing existing versions like v3.3.0.