### PR TITLE
fix: use aspect-ratio CSS property for proper 16:9 video dimensions

### DIFF
--- a/src/lib/LiteYouTubeEmbed.css
+++ b/src/lib/LiteYouTubeEmbed.css
@@ -6,6 +6,7 @@
   background-position: 50%;
   background-size: cover;
   cursor: pointer;
+  aspect-ratio: 16 / 9;
 }
 
 .yt-lite.lyt-activated::before {
@@ -22,10 +23,18 @@
   width: 100%;
   transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
+/* Fallback for browsers without aspect-ratio support */
 .yt-lite::after {
   content: "";
   display: block;
   padding-bottom: var(--aspect-ratio, 56.25%);
+}
+
+/* Modern browsers: aspect-ratio takes precedence, hide the padding hack */
+@supports (aspect-ratio: 16 / 9) {
+  .yt-lite::after {
+    display: none;
+  }
 }
 .yt-lite > iframe {
   width: 100%;


### PR DESCRIPTION
## Summary

- Adds modern `aspect-ratio: 16 / 9` property to `.yt-lite` class
- Fixes stretched/elongated video embeds that occur without explicit aspect ratio
- Maintains backward compatibility with padding-bottom hack for older browsers via `@supports`

## Problem

The video embed container was missing an explicit aspect ratio, causing videos to appear stretched or elongated in some contexts where the container's dimensions weren't constrained.

## Solution

Use the CSS `aspect-ratio` property which is now widely supported (96%+ global browser support per caniuse.com). The old padding-bottom hack is kept as a fallback but hidden in modern browsers using `@supports`.

## Test plan

- [ ] Verify video embeds maintain 16:9 aspect ratio
- [ ] Test in modern browsers (Chrome, Firefox, Safari, Edge)
- [ ] Confirm fallback works in older browsers without aspect-ratio support

🤖 Generated with [Claude Code](https://claude.com/claude-code)