### PR TITLE
fix: remove redundant role="img" when lazyLoad is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibrahimcesar/react-lite-youtube-embed",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "A private by default, faster and cleaner YouTube embed component for React applications",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -740,7 +740,7 @@ function LiteYouTubeEmbedComponent(
         onClick={addIframe}
         className={`${wrapperClassImp} ${iframe ? activatedClassImp : ""}`}
         data-title={videoTitle}
-        role={!iframe ? "img" : undefined}
+        role={!iframe && !props.lazyLoad ? "img" : undefined}
         aria-label={
           !iframe ? `${videoTitle} - YouTube video preview` : undefined
         }


### PR DESCRIPTION
## Summary

Fixes #249

When `lazyLoad={true}`, the component renders an actual `<img>` element inside the container for the thumbnail. However, the container also had `role="img"` applied, creating redundant ARIA semantics that fail automated accessibility audits (Axe, Lighthouse, WAVE).

- Conditionally apply `role="img"` only when `lazyLoad` is **not** enabled and the iframe is inactive
- When `lazyLoad` is enabled, the real `<img>` element already provides correct semantics for assistive technologies
- When `lazyLoad` is disabled (CSS background-image), `role="img"` is still applied since there's no native image element
- Bumps version from 3.3.3 to 3.4.0

## Test plan

- [x] All 51 existing tests pass
- [ ] Verify with `lazyLoad={true}`: container should **not** have `role="img"`, the inner `<img>` handles semantics
- [ ] Verify with `lazyLoad={false}` (default): container should still have `role="img"` as before
- [ ] Run accessibility audit (Axe/Lighthouse) — redundant role error should be resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)