### PR TITLE
fix: use unscoped package name for NPM publish

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -240,36 +240,15 @@ jobs:
               --notes-file CHANGELOG.md
           fi
 
-      - name: Publish to NPM (scoped package)
+      - name: Publish to NPM
         run: |
-          # Publish scoped package (@ibrahimcesar/react-lite-youtube-embed)
           # Auth is handled via OIDC (Trusted Publishers) — no token needed
-          echo "Publishing scoped package: @ibrahimcesar/react-lite-youtube-embed"
+          echo "Publishing package: react-lite-youtube-embed"
           if [ "${{ github.event.inputs.is_beta }}" == "true" ]; then
             npm publish --tag beta --provenance --access public
           else
             npm publish --provenance --access public
           fi
-
-      - name: Publish to NPM (unscoped package)
-        run: |
-          # Backup original package.json
-          cp package.json package.json.backup
-
-          # Modify package.json to use unscoped name
-          node -e "const pkg = require('./package.json'); pkg.name = 'react-lite-youtube-embed'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));"
-
-          # Publish unscoped package (react-lite-youtube-embed)
-          # Auth is handled via OIDC (Trusted Publishers) — no token needed
-          echo "Publishing unscoped package: react-lite-youtube-embed"
-          if [ "${{ github.event.inputs.is_beta }}" == "true" ]; then
-            npm publish --tag beta --provenance --access public
-          else
-            npm publish --provenance --access public
-          fi
-
-          # Restore original package.json
-          mv package.json.backup package.json
 
       - name: Setup Node for GitHub Packages
         uses: actions/setup-node@v6
@@ -317,13 +296,11 @@ jobs:
           echo "### 🔗 Links" >> $GITHUB_STEP_SUMMARY
           echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump_version.outputs.version }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**NPM Packages:**" >> $GITHUB_STEP_SUMMARY
+          echo "**NPM:**" >> $GITHUB_STEP_SUMMARY
           if [ "${{ github.event.inputs.is_beta }}" == "true" ]; then
-            echo "- [Scoped Package (beta)](https://www.npmjs.com/package/@ibrahimcesar/react-lite-youtube-embed/v/${{ steps.clean_version.outputs.version }}) - \`@ibrahimcesar/react-lite-youtube-embed\`" >> $GITHUB_STEP_SUMMARY
-            echo "- [Unscoped Package (beta)](https://www.npmjs.com/package/react-lite-youtube-embed/v/${{ steps.clean_version.outputs.version }}) - \`react-lite-youtube-embed\`" >> $GITHUB_STEP_SUMMARY
+            echo "- [react-lite-youtube-embed (beta)](https://www.npmjs.com/package/react-lite-youtube-embed/v/${{ steps.clean_version.outputs.version }})" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- [Scoped Package](https://www.npmjs.com/package/@ibrahimcesar/react-lite-youtube-embed/v/${{ steps.clean_version.outputs.version }}) - \`@ibrahimcesar/react-lite-youtube-embed\`" >> $GITHUB_STEP_SUMMARY
-            echo "- [Unscoped Package](https://www.npmjs.com/package/react-lite-youtube-embed/v/${{ steps.clean_version.outputs.version }}) - \`react-lite-youtube-embed\`" >> $GITHUB_STEP_SUMMARY
+            echo "- [react-lite-youtube-embed](https://www.npmjs.com/package/react-lite-youtube-embed/v/${{ steps.clean_version.outputs.version }})" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**GitHub Packages:**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,28 +83,11 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Publish to NPM (scoped package)
+      - name: Publish to NPM
         run: |
-          # Publish scoped package (@ibrahimcesar/react-lite-youtube-embed)
           # Auth is handled via OIDC (Trusted Publishers) — no token needed
-          echo "Publishing scoped package: @ibrahimcesar/react-lite-youtube-embed"
+          echo "Publishing package: react-lite-youtube-embed"
           npm publish --provenance --access public
-
-      - name: Publish to NPM (unscoped package)
-        run: |
-          # Backup original package.json
-          cp package.json package.json.backup
-
-          # Modify package.json to use unscoped name
-          node -e "const pkg = require('./package.json'); pkg.name = 'react-lite-youtube-embed'; require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));"
-
-          # Publish unscoped package (react-lite-youtube-embed)
-          # Auth is handled via OIDC (Trusted Publishers) — no token needed
-          echo "Publishing unscoped package: react-lite-youtube-embed"
-          npm publish --provenance --access public
-
-          # Restore original package.json
-          mv package.json.backup package.json
 
   publish-github:
     name: Publish on GitHub Packages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ibrahimcesar/react-lite-youtube-embed",
-  "version": "3.4.0",
+  "name": "react-lite-youtube-embed",
+  "version": "3.5.0",
   "description": "A private by default, faster and cleaner YouTube embed component for React applications",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Fixes the `E404 Not Found` error when publishing to NPM. The package lives at `react-lite-youtube-embed` (unscoped), not `@ibrahimcesar/react-lite-youtube-embed`.

- **Renamed** package in `package.json` from `@ibrahimcesar/react-lite-youtube-embed` to `react-lite-youtube-embed`
- **Removed** the scoped publish step from both `release.yml` and `auto-release.yml`
- **Simplified** the publish step — no more backup/rename of `package.json` needed since the name is now correct
- **Cleaned up** release summary to remove scoped package references
- **Bumped** version to 3.5.0

## Test plan

- [ ] Merge and trigger `auto-release.yml` — verify NPM publish succeeds without E404
- [ ] Verify package appears at https://www.npmjs.com/package/react-lite-youtube-embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)