### PR TITLE
ci: upgrade npm before publish so Trusted Publishing OIDC works

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -242,7 +242,10 @@ jobs:
 
       - name: Publish to NPM
         run: |
-          # Auth is handled via OIDC (Trusted Publishers) — no token needed
+          # Auth is handled via OIDC (Trusted Publishers) — no token needed.
+          # Trusted Publishing requires npm >= 11.5.1, but Node 22 bundles npm 10,
+          # which skips the OIDC exchange and fails the publish with E404.
+          npm install -g npm@latest
           echo "Publishing package: react-lite-youtube-embed"
           if [ "${{ github.event.inputs.is_beta }}" == "true" ]; then
             npm publish --tag beta --provenance --access public


### PR DESCRIPTION
## Summary

The v3.6.1 release run of `auto-release.yml` failed at the **Publish to NPM** step with `npm error 404 Not Found - PUT https://registry.npmjs.org/react-lite-youtube-embed` (run [31289211594](https://github.com/ibrahimcesar/react-lite-youtube-embed/actions/runs/31289211594)).

**Root cause:** the publish step relies on NPM Trusted Publishers (OIDC) with no token, but the job uses Node 22, which bundles npm 10.x. The OIDC token exchange for Trusted Publishing requires **npm ≥ 11.5.1**, so npm 10 published unauthenticated and the registry rejected it with a masked 404. (v3.6.1 was subsequently published successfully by dispatching `release.yml`, which authenticates with `NPM_TOKEN`.)

**Fix:** upgrade npm to latest in the publish step before `npm publish`, so the OIDC exchange actually happens.

> **Note for maintainer:** this assumes a Trusted Publisher is configured on npmjs.com for this package pointing at `auto-release.yml`. If it is not (or it points at `release.yml`), either update the Trusted Publisher config or switch this step back to `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.

## Test plan

- [x] YAML validated locally
- [ ] Verified on the next release run (`workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)