### PR TITLE
ci: publish with NPM_TOKEN in auto-release until Trusted Publisher is configured

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -241,10 +241,14 @@ jobs:
           fi
 
       - name: Publish to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          # Auth is handled via OIDC (Trusted Publishers) — no token needed.
-          # Trusted Publishing requires npm >= 11.5.1, but Node 22 bundles npm 10,
-          # which skips the OIDC exchange and fails the publish with E404.
+          # Token auth, same as release.yml. OIDC (Trusted Publishers) failed with
+          # E404 on the v3.6.1 and v3.6.2 releases — no Trusted Publisher is
+          # configured on npmjs.com for this workflow. If one is added
+          # (Settings → Trusted Publisher, workflow: auto-release.yml), the
+          # NODE_AUTH_TOKEN env above can be removed.
           npm install -g npm@latest
           echo "Publishing package: react-lite-youtube-embed"
           if [ "${{ github.event.inputs.is_beta }}" == "true" ]; then


### PR DESCRIPTION
## Summary

The `auto-release.yml` NPM publish failed with `E404` on **both** the v3.6.1 and v3.6.2 releases — even after #297 upgraded npm so the OIDC exchange could run. That confirms there is **no Trusted Publisher configured on npmjs.com for `auto-release.yml`**; both versions had to be published by manually dispatching `release.yml`, which authenticates with `NPM_TOKEN` and succeeds.

This switches the auto-release publish step to the same `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` auth (the job's setup-node already sets `registry-url`), so the next release publishes end-to-end in one run.

## To move to Trusted Publishers later (optional, maintainer-only)

On npmjs.com → `react-lite-youtube-embed` → Settings → Trusted Publisher: add GitHub Actions publisher with repository `ibrahimcesar/react-lite-youtube-embed` and workflow `auto-release.yml`. Then the `NODE_AUTH_TOKEN` line can be removed.

## Test plan

- [x] Same auth pattern as `release.yml`, which published v3.6.1 and v3.6.2 successfully
- [ ] Verified end-to-end on the next release dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)