### PR TITLE
ci: route all NPM publishing through release.yml (npm Trusted Publisher)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -27,6 +27,7 @@ jobs:
       contents: write
       pull-requests: read
       packages: write
+      actions: write  # Required to dispatch release.yml for the NPM publish
       id-token: write  # Required for SLSA provenance
       attestations: write  # Required for build attestations
 
@@ -240,22 +241,39 @@ jobs:
               --notes-file CHANGELOG.md
           fi
 
-      - name: Publish to NPM
+      - name: Publish to NPM (via release.yml)
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Token auth, same as release.yml. OIDC (Trusted Publishers) failed with
-          # E404 on the v3.6.1 and v3.6.2 releases — no Trusted Publisher is
-          # configured on npmjs.com for this workflow. If one is added
-          # (Settings → Trusted Publisher, workflow: auto-release.yml), the
-          # NODE_AUTH_TOKEN env above can be removed.
-          npm install -g npm@latest
-          echo "Publishing package: react-lite-youtube-embed"
+          # All NPM publishing goes through release.yml — the workflow registered
+          # as the npm Trusted Publisher (OIDC). Main already has the version
+          # bump commit pushed above, so the dispatched run publishes it.
+          # (workflow_dispatch is one of the two events GITHUB_TOKEN may trigger.)
           if [ "${{ github.event.inputs.is_beta }}" == "true" ]; then
-            npm publish --tag beta --provenance --access public
+            NPM_TAG="beta"
           else
-            npm publish --provenance --access public
+            NPM_TAG="latest"
           fi
+
+          DISPATCHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run release.yml --ref main -f npm_tag="$NPM_TAG"
+
+          # Find the run we just dispatched and wait for it, so this release
+          # fails loudly if the publish fails.
+          RUN_ID=""
+          for _ in $(seq 1 12); do
+            sleep 5
+            RUN_ID=$(gh run list --workflow=release.yml \
+              --created ">=$DISPATCHED_AT" --limit 1 \
+              --json databaseId --jq '.[0].databaseId // empty')
+            [ -n "$RUN_ID" ] && break
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::release.yml run did not start"
+            exit 1
+          fi
+          echo "Waiting on release.yml run $RUN_ID"
+          gh run watch "$RUN_ID" --exit-status
 
       - name: Setup Node for GitHub Packages
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,15 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      npm_tag:
+        description: 'npm dist-tag to publish with'
+        required: false
+        default: 'latest'
+        type: choice
+        options:
+          - latest
+          - beta
 
 jobs:
   tag:
@@ -84,7 +93,17 @@ jobs:
           path: dist/
 
       - name: Publish to NPM
-        run: npm publish --provenance --access public
+        run: |
+          # This workflow is the npm Trusted Publisher (OIDC) for the package.
+          # The OIDC exchange needs npm >= 11.5.1; Node 22 bundles npm 10.
+          npm install -g npm@latest
+          if [ "${{ inputs.npm_tag }}" == "beta" ]; then
+            npm publish --tag beta --provenance --access public
+          else
+            npm publish --provenance --access public
+          fi
         env:
+          # Fallback auth; OIDC takes precedence when the Trusted Publisher is
+          # configured on npmjs.com. Remove once an OIDC publish has succeeded.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

npm allows **one** Trusted Publisher workflow per package, and `release.yml` is being registered as it. This PR makes that the single publish path while keeping the automated flow end-to-end:

- **`auto-release.yml`** no longer publishes to npm directly. After pushing the version bump, tag, and GitHub Release, it dispatches `release.yml` (allowed for `GITHUB_TOKEN` — `workflow_dispatch` is exempt from the recursive-trigger block) and **waits on the dispatched run**, so a failed publish still fails the release run. Requires the new `actions: write` permission, added.
- **`release.yml`** gains an `npm_tag` input (`latest`/`beta`) so beta releases keep their dist-tag when published through it, and upgrades npm before `npm publish` because the Trusted Publishing OIDC exchange requires npm ≥ 11.5.1 (Node 22 bundles npm 10). `NODE_AUTH_TOKEN` stays as fallback until an OIDC publish is confirmed, then can be removed — OIDC takes precedence when both are available.
- `release.yml` remains directly callable (`gh workflow run release.yml`) to publish whatever version is on main — the rescue path used for v3.6.1 and v3.6.2.

## Prerequisite (maintainer)

On npmjs.com → package Settings → Trusted Publisher: GitHub Actions, `ibrahimcesar/react-lite-youtube-embed`, workflow `release.yml`, **no environment name**, allow Publish.

## Test plan

- [x] YAML lint on both workflows
- [ ] Next release via auto-release dispatch verifies the full chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)